### PR TITLE
On each dialog routing the IP of the sender will be compared with the…

### DIFF
--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1000,6 +1000,21 @@ static inline void log_bogus_dst_leg(struct dlg_cell *dlg)
 			dlg_leg_print_info( dlg, callee_idx(dlg), tag),dlg->legs_no[DLG_LEGS_USED]);
 }
 
+void update_dialog_route (struct sip_msg* req, struct dlg_cell *dlg, unsigned int src_leg) {
+	struct dlg_leg * leg = &dlg->legs[src_leg];
+	int is_req = (req->first_line.type==SIP_REQUEST)?1:0;
+	unsigned int skip_recs = 0;
+	str contact;
+	str rr_set;
+	get_routing_info(req, is_req, &skip_recs, &contact, &rr_set);
+	if ( contact.len != 0 && (contact.len != leg->contact.len || strncmp(contact.s,leg->contact.s,leg->contact.len)) != 0) {
+		LM_DBG("Leg has a new IP, updating contact. Old contact=%.*s, new contact=%.*s\n", leg->contact.len, leg->contact.s, contact.len, contact.s);
+        dlg_lock_dlg(dlg);
+		dlg_update_leg_contact(leg, &rr_set, &contact);
+        dlg_unlock_dlg(dlg);
+	}
+}
+
 void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 {
 	struct dlg_cell *dlg;
@@ -1038,6 +1053,7 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 	dlg = 0;
 	dir = DLG_DIR_NONE;
 	dst_leg = -1;
+    src_leg = -1;
 
 	/* From RR callback, param will be NULL
 	 * From match_dialog, param might have a value, if we
@@ -1070,7 +1086,7 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 					unref_dlg(dlg, 1);
 					return;
 				}
-				if (match_dialog(dlg,&callid,&ftag,&ttag,&dir, &dst_leg )==0){
+				if (match_dialog(dlg, &callid, &ftag, &ttag, &dir, &dst_leg, &src_leg) == 0) {
 					if (!accept_replicated_dlg) {
 						/* not an error when accepting replicating dialogs -
 						   we might have generated a different h_id when
@@ -1110,7 +1126,7 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 			return;
 		/* TODO - try to use the RR dir detection to speed up here the
 		 * search -bogdan */
-		dlg = get_dlg(&callid, &ftag, &ttag, &dir, &dst_leg);
+		dlg = get_dlg(&callid, &ftag, &ttag, &dir, &dst_leg, &src_leg);
 		if (!dlg){
 			LM_DBG("Callid '%.*s' not found\n",
 				req->callid->body.len, req->callid->body.s);
@@ -1118,6 +1134,7 @@ void dlg_onroute(struct sip_msg* req, str *route_params, void *param)
 		}
 	}
 
+	update_dialog_route(req, dlg, src_leg);
 	/* run state machine */
 	switch ( req->first_line.u.request.method_value ) {
 		case METHOD_PRACK:

--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -1001,6 +1001,9 @@ static inline void log_bogus_dst_leg(struct dlg_cell *dlg)
 }
 
 void update_dialog_route (struct sip_msg* req, struct dlg_cell *dlg, unsigned int src_leg) {
+    if (src_leg < 0){
+        return;
+    }
 	struct dlg_leg * leg = &dlg->legs[src_leg];
 	int is_req = (req->first_line.type==SIP_REQUEST)?1:0;
 	unsigned int skip_recs = 0;

--- a/modules/dialog/dlg_hash.c
+++ b/modules/dialog/dlg_hash.c
@@ -326,6 +326,44 @@ struct dlg_cell* build_new_dlg( str *callid, str *from_uri, str *to_uri,
 	return dlg;
 }
 
+int dlg_update_leg_contact(struct dlg_leg *leg, str *rr, str *contact) {
+    rr_t *head = NULL, *rrp;
+
+    if (contact->len) {
+        /* contact */
+        if (leg->contact.s != NULL) {
+            shm_free(leg->contact.s);
+        }
+        leg->contact.s = shm_malloc(rr->len + contact->len);
+        if (leg->contact.s == NULL) {
+            LM_ERR("no more shm mem\n");
+            return -1;
+        }
+        leg->contact.len = contact->len;
+        memcpy(leg->contact.s, contact->s, contact->len);
+        /* rr */
+        if (rr->len) {
+            leg->route_set.s = leg->contact.s + contact->len;
+            leg->route_set.len = rr->len;
+            memcpy(leg->route_set.s, rr->s, rr->len);
+            if (parse_rr_body(leg->route_set.s, leg->route_set.len, &head) != 0) {
+                LM_ERR("failed parsing route set\n");
+                shm_free(leg->contact.s);
+                return -1;
+            }
+            rrp = head;
+            leg->nr_uris = 0;
+            while (rrp) {
+                leg->route_uris[leg->nr_uris++] = rrp->nameaddr.uri;
+                rrp = rrp->next;
+            }
+            free_rr(&head);
+        }
+    }
+
+    return 0;
+}
+
 /* first time it will called for a CALLER leg - at that time there will
    be no leg allocated, so automatically CALLER gets the first position, while
    the CALLEE legs will follow into the array in the same order they came */
@@ -334,7 +372,6 @@ int dlg_add_leg_info(struct dlg_cell *dlg, str* tag, str *rr,
 		str *mangled_from,str *mangled_to)
 {
 	struct dlg_leg* leg,*new_legs;
-	rr_t *head = NULL, *rrp;
 
 	if ( (dlg->legs_no[DLG_LEGS_ALLOCED]-dlg->legs_no[DLG_LEGS_USED])==0) {
 		new_legs = (struct dlg_leg*)shm_realloc(dlg->legs,
@@ -370,39 +407,12 @@ int dlg_add_leg_info(struct dlg_cell *dlg, str* tag, str *rr,
 		}
 	}
 
-	if (contact->len) {
-		/* contact */
-		leg->contact.s = shm_malloc(rr->len + contact->len);
-		if (leg->contact.s==NULL) {
-			LM_ERR("no more shm mem\n");
-			shm_free(leg->tag.s);
-			shm_free(leg->r_cseq.s);
-			return -1;
-		}
-		leg->contact.len = contact->len;
-		memcpy( leg->contact.s, contact->s, contact->len);
-		/* rr */
-		if (rr->len) {
-			leg->route_set.s = leg->contact.s + contact->len;
-			leg->route_set.len = rr->len;
-			memcpy( leg->route_set.s, rr->s, rr->len);
-
-			if (parse_rr_body(leg->route_set.s,leg->route_set.len,&head) != 0) {
-				LM_ERR("failed parsing route set\n");
-				shm_free(leg->tag.s);
-				shm_free(leg->r_cseq.s);
-				shm_free(leg->contact.s);
-				return -1;
-			}
-			rrp = head;
-			leg->nr_uris = 0;
-			while (rrp) {
-				leg->route_uris[leg->nr_uris++] = rrp->nameaddr.uri;
-				rrp = rrp->next;
-			}
-			free_rr(&head);
-		}
-	}
+    if (dlg_update_leg_contact(leg, rr, contact) == -1){
+        shm_free(leg->tag.s);
+        shm_free(leg->r_cseq.s);
+        shm_free(leg->contact.s);
+        return -1;
+    }
 
 	/* save mangled from URI, if any */
 	if (mangled_from && mangled_from->s && mangled_from->len) {
@@ -609,7 +619,7 @@ not_found:
 /* defines a peer-to-peer SIP relationship between [two UAs] and is  */
 /* referred to as a dialog."*/
 struct dlg_cell* get_dlg( str *callid, str *ftag, str *ttag,
-									unsigned int *dir, unsigned int *dst_leg)
+									unsigned int *dir, unsigned int *dst_leg, unsigned int *src_leg)
 {
 	struct dlg_cell *dlg;
 	struct dlg_entry *d_entry;
@@ -638,7 +648,7 @@ struct dlg_cell* get_dlg( str *callid, str *ftag, str *ttag,
 			dlg->legs[DLG_CALLER_LEG].contact.len,
 				dlg->legs[DLG_CALLER_LEG].contact.len);
 #endif
-		if (match_dialog( dlg, callid, ftag, ttag, dir, dst_leg)==1) {
+		if (match_dialog( dlg, callid, ftag, ttag, dir, dst_leg, src_leg)==1) {
 			if (dlg->state==DLG_STATE_DELETED)
 				/* even if matched, skip the deleted dialogs as they may be
 				   a previous unsuccessfull attempt of established call

--- a/modules/dialog/dlg_hash.h
+++ b/modules/dialog/dlg_hash.h
@@ -300,6 +300,8 @@ int dlg_add_leg_info(struct dlg_cell *dlg, str* tag, str *rr,
 		str *contact,str *cseq, struct socket_info *sock,
 		str *mangled_from,str *mangled_to);
 
+int dlg_update_leg_contact(struct dlg_leg *leg, str *rr, str *contact);
+
 int dlg_update_cseq(struct dlg_cell *dlg, unsigned int leg, str *cseq,
 						int field_type);
 
@@ -309,7 +311,7 @@ int dlg_update_routing(struct dlg_cell *dlg, unsigned int leg,
 struct dlg_cell* lookup_dlg( unsigned int h_entry, unsigned int h_id);
 
 struct dlg_cell* get_dlg(str *callid, str *ftag, str *ttag,
-		unsigned int *dir, unsigned int *dst_leg);
+		unsigned int *dir, unsigned int *dst_leg, unsigned int *src_leg);
 
 struct dlg_cell* get_dlg_by_val(str *attr, str *val);
 
@@ -332,7 +334,7 @@ static inline void unref_dlg_destroy_safe(struct dlg_cell *dlg, unsigned int cnt
 }
 
 static inline int match_dialog(struct dlg_cell *dlg, str *callid,
-			str *ftag, str *ttag, unsigned int *dir, unsigned int *dst_leg) {
+			str *ftag, str *ttag, unsigned int *dir, unsigned int *dst_leg, unsigned int * src_leg) {
 	str *tag;
 	unsigned int i;
 
@@ -348,6 +350,7 @@ static inline int match_dialog(struct dlg_cell *dlg, str *callid,
 		/* from tag = from tag matching */
 		*dir = DLG_DIR_DOWNSTREAM;
 		tag = ttag;
+		*src_leg = 0;
 	} else if (dlg->legs[DLG_CALLER_LEG].tag.len == ttag->len &&
 	strncmp(dlg->legs[DLG_CALLER_LEG].tag.s, ttag->s, ttag->len)==0 ) {
 		/* from tag = to tag matching */
@@ -365,6 +368,7 @@ static inline int match_dialog(struct dlg_cell *dlg, str *callid,
 			if (dlg->legs[i].tag.len == tag->len &&
 			strncmp(dlg->legs[i].tag.s, tag->s, tag->len)==0 ) {
 				if (*dst_leg==-1) *dst_leg = i; /* destination is callee */
+				if (*src_leg==-1) *src_leg = i; /* source is callee */
 				return 1;
 			}
 		}

--- a/modules/dialog/dlg_replication.c
+++ b/modules/dialog/dlg_replication.c
@@ -77,8 +77,8 @@ static struct socket_info * fetch_socket_info(str *addr)
  */
 int dlg_replicated_create(struct dlg_cell *cell, str *ftag, str *ttag, int safe)
 {
-	int h_entry;
-	unsigned int dir, dst_leg;
+	int next_id, h_entry;
+	unsigned int dir, dst_leg, src_leg;
 	str callid, from_uri, to_uri, from_tag, to_tag;
 	str cseq1,cseq2,contact1,contact2,rroute1,rroute2,mangled_fu,mangled_tu;
 	str sock, vars, profiles;
@@ -96,7 +96,7 @@ int dlg_replicated_create(struct dlg_cell *cell, str *ftag, str *ttag, int safe)
 		bin_pop_str(&from_uri);
 		bin_pop_str(&to_uri);
 
-		dlg = get_dlg(&callid, &from_tag, &to_tag, &dir, &dst_leg);
+		dlg = get_dlg(&callid, &from_tag, &to_tag, &dir, &dst_leg, &src_leg);
 
 		h_entry = dlg_hash(&callid);
 		d_entry = &d_table->entries[h_entry];
@@ -273,7 +273,7 @@ int dlg_replicated_update(void)
 {
 	struct dlg_cell *dlg;
 	str call_id, from_tag, to_tag, from_uri, to_uri, vars, profiles;
-	unsigned int dir, dst_leg;
+	unsigned int dir, dst_leg, src_leg;
 	int timeout, h_entry;
 	str st;
 	struct dlg_entry *d_entry;
@@ -288,7 +288,7 @@ int dlg_replicated_update(void)
 	call_id.len, call_id.s, from_tag.len, from_tag.s, to_tag.len, to_tag.s,
 	from_uri.len, from_uri.s, to_uri.len, to_uri.s);
 
-	dlg = get_dlg(&call_id, &from_tag, &to_tag, &dir, &dst_leg);
+	dlg = get_dlg(&call_id, &from_tag, &to_tag, &dir, &dst_leg, &src_leg);
 
 	h_entry = dlg_hash(&call_id);
 	d_entry = &d_table->entries[h_entry];
@@ -376,7 +376,7 @@ error:
 int dlg_replicated_delete(void)
 {
 	str call_id, from_tag, to_tag;
-	unsigned int dir, dst_leg;
+	unsigned int dir, dst_leg, src_leg;
 	struct dlg_cell *dlg;
 	int old_state, new_state, unref, ret;
 
@@ -386,7 +386,7 @@ int dlg_replicated_delete(void)
 
 	LM_DBG("Deleting dialog with callid: %.*s\n", call_id.len, call_id.s);
 
-	dlg = get_dlg(&call_id, &from_tag, &to_tag, &dir, &dst_leg);
+	dlg = get_dlg(&call_id, &from_tag, &to_tag, &dir, &dst_leg, &src_leg);
 	if (!dlg) {
 	        LM_ERR("dialog not found (callid: |%.*s| ftag: |%.*s|\n",
 	                call_id.len, call_id.s, from_tag.len, from_tag.s);


### PR DESCRIPTION
… IP stored in the dialog. If they are not the same the contact will be updated. This fixes the issue where if a mobile device moves between networks and sends a reinvade, the dialog does not get updated with the new IP.